### PR TITLE
Add pkgdown author profiles

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -6,7 +6,6 @@ template:
 authors:
   "George Vega Yon":
     href: "https://ggvy.cl"
-    html: "<img src='https://ggvy.cl/img/george-g-vega-yon-university-of-utah.webp' width=72 alt=''>"
   "Porter Bischoff":
     href: "https://orcid.org/0009-0004-6742-6281"
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -3,6 +3,13 @@ url: https://usccana.github.io/netplot/
 template:
   bootstrap: 5
 
+authors:
+  "George Vega Yon":
+    href: "https://ggvy.cl"
+    html: "<img src='https://ggvy.cl/img/george-g-vega-yon-university-of-utah.webp' width=72 alt=''>"
+  "Porter Bischoff":
+    href: "https://orcid.org/0009-0004-6742-6281"
+
 reference:
 - title: "Drawing networks"
   desc: >


### PR DESCRIPTION
## Summary

- link George Vega Yon to https://ggvy.cl while preserving his displayed name
- add profile links for every package author listed in DESCRIPTION
- add a source pkgdown configuration where the published site did not already have one

## Validation

- loaded the package metadata with pkgdown
- verified exact author-name matching against DESCRIPTION
- verified every configured author mapping contains only an href attribute

Related to gvegayon/website#32.